### PR TITLE
fixed ros.h not found on melodic

### DIFF
--- a/point_cloud_spatial_filter/CMakeLists.txt
+++ b/point_cloud_spatial_filter/CMakeLists.txt
@@ -97,7 +97,7 @@ catkin_package(
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
-include_directories(include)
+include_directories(${catkin_INCLUDE_DIRS} include)
 
 ## Declare a cpp library
 add_library(point_cloud_spatial_filter


### PR DESCRIPTION
Wasn't able to compile on ROS melodic but the solution was in the CMakeLists.txt. Always gave the error <ros/ros.h> No such file or directory.

 In my case also needed to create a symbolic link like 
```bash
sudo ln -s /usr/lib/x86_64-linux-gnu/libGL.so.1 /usr/lib/x86_64-linux-gnu/libGL.so
```